### PR TITLE
Remove the duplication and use the local

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,10 @@ data "aws_route53_zone" "dns_domain" {
   name = "${data.template_file.domain.rendered}"
 }
 
+locals {
+  fqdn = "${var.env == "live" ? "${var.name}" : "${var.env}-${var.name}"}.${data.template_file.domain.rendered}"
+}
+
 data "template_file" "domain" {
   template = "$${env == "live" ? "$${domain}" : "dev.$${domain}"}."
 
@@ -19,7 +23,7 @@ resource "aws_route53_record" "dns_record" {
   count = "${1 - var.alias}"
 
   zone_id = "${data.aws_route53_zone.dns_domain.zone_id}"
-  name    = "${var.env == "live" ? "${var.name}" : "${var.env}-${var.name}"}.${data.template_file.domain.rendered}"
+  name    = "${local.fqdn}"
 
   type    = "CNAME"
   records = ["${var.target}"]
@@ -34,7 +38,7 @@ resource "aws_route53_record" "alb_alias" {
   count = "${var.alias}"
 
   zone_id = "${data.aws_route53_zone.dns_domain.zone_id}"
-  name    = "${var.env == "live" ? "${var.name}" : "${var.env}-${var.name}"}.${data.template_file.domain.rendered}"
+  name    = "${local.fqdn}"
   type    = "A"
 
   alias {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,3 @@
 output "fqdn" {
-  value = "${element(
-    compact(
-        concat(
-            aws_route53_record.dns_record.*.fqdn,
-            aws_route53_record.alb_alias.*.fqdn
-        )
-    ), 0)}"
+  value = "${local.fqdn}"
 }


### PR DESCRIPTION
This is worse in a way in that we lose the dendency, but we found it failed because the fqdn attribute was empty the first time.

Not sure if this is the right fix - ideally the behaviour of the terraform provider would be fixed. 